### PR TITLE
DevOps Update

### DIFF
--- a/site/content/problems/devops/index.md
+++ b/site/content/problems/devops/index.md
@@ -7,7 +7,7 @@ description: "Delivery risk increases when the system of work cannot reliably tu
 keywords: ["devops consulting", "delivery risk", "engineering operating model", "systems of work", "flow and feedback loops", "predictable delivery", "decision latency", "engineering leadership", "software delivery capability", "devops beyond tools"]
 triage:
   title: "DevOps: Delivery isn’t improving"
-  signal: "If you are adding people and resources but delivery isn’t improving, increasing speed or meeting technical objectives."
+  signal: "You are adding people and resources but delivery isn't improving speed or meeting technical objectives."
 related:
   - "/outcomes/engineering-excellence"
   - "/outcomes/technical-leadership"


### PR DESCRIPTION
This pull request updates the triage section in the DevOps problem statement to better reflect the challenges organizations face when delivery performance does not improve despite adding resources.

- **Content clarity improvements:**
  * Updated the triage `title` to "DevOps: Delivery isn’t improving" for more accurate framing.
  * Revised the triage `signal` to clarify that adding people and resources without seeing improvements in delivery speed or technical objectives is a key indicator.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated DevOps problem title to "DevOps: Delivery isn’t improving" for clearer framing.
  * Refined triage guidance to emphasise that adding people or resources without improving delivery speed or meeting technical objectives indicates the issue.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->